### PR TITLE
Updates to mix.exs, app.js and package.json 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 /deps
 /*.ez
 
+# Static artifacts
+/assets/node_modules
+
 # Generated on crash by the VM
 erl_crash.dump
 

--- a/assets/package.json
+++ b/assets/package.json
@@ -10,13 +10,13 @@
     "build": "cross-env NODE_ENV=production webpack --progress --hide-modules"
   },
   "dependencies": {
-    "vue": "^2.5.11",
+    "apollo-cache-inmemory": "^1.2.10",
+    "apollo-client": "^2.4.2",
+    "apollo-link-http": "^1.5.5",
     "graphql": "^0.11.0",
-    "vue-apollo": "^3.0.0-alpha.2",
-    "apollo-client": "^2.0.0",
-    "apollo-cache-inmemory": "^1.1.4",
-    "apollo-link-http": "^1.3.2",
-    "graphql-tag": "^2.6.0"
+    "graphql-tag": "^2.9.2",
+    "vue": "^2.5.17",
+    "vue-apollo": "^3.0.0-beta.25"
   },
   "browserslist": [
     "> 1%",
@@ -24,18 +24,18 @@
     "not ie <= 8"
   ],
   "devDependencies": {
-    "babel-core": "^6.26.0",
-    "babel-loader": "^7.1.2",
-    "babel-preset-env": "^1.6.0",
+    "babel-core": "^6.26.3",
+    "babel-loader": "^7.1.5",
+    "babel-preset-env": "^1.7.0",
     "babel-preset-stage-3": "^6.24.1",
-    "cross-env": "^5.0.5",
-    "css-loader": "^0.28.7",
-    "file-loader": "^1.1.4",
-    "node-sass": "^4.5.3",
-    "sass-loader": "^6.0.6",
-    "vue-loader": "^13.0.5",
-    "vue-template-compiler": "^2.4.4",
-    "webpack": "^3.6.0",
-    "webpack-dev-server": "^2.9.1"
+    "cross-env": "^5.2.0",
+    "css-loader": "^0.28.11",
+    "file-loader": "^1.1.11",
+    "node-sass": "^4.9.3",
+    "sass-loader": "^6.0.7",
+    "vue-loader": "^13.7.3",
+    "vue-template-compiler": "^2.5.17",
+    "webpack": "^3.12.0",
+    "webpack-dev-server": "^2.11.3"
   }
 }

--- a/mix.exs
+++ b/mix.exs
@@ -40,7 +40,7 @@ defmodule Vuegraphqlphx.Mixfile do
       {:phoenix_html, "~> 2.10"},
       {:gettext, "~> 0.11"},
       {:cowboy, "~> 1.0"},
-      {:absinthe, "~> 1.4.0"},
+      {:absinthe, "~> 1.4.13"},
       {:absinthe_plug, "~> 1.4"},
       {:poison, "~> 3.1.0"} # JSON parser
     ]


### PR DESCRIPTION
First, thanks for that great article "How To Setup GraphQL, Vue.js, and Phoenix 1.3", it was big help to me. 

There were a few changes I needed to compile with the last versions of Elixir and Apollo.

For Elixir 1.7.3, I needed to update Absinthe to v1.4.13 to fix an 'Invalid schema' error

For the Vue app, I was encountering an 'Uncaught TypeError: apolloProvider.provide is not a function' error, and I needed to change 'provide: apolloProvider.provide()' to 'apolloProvider' in app.js

I also updated package.json via 'npm update' for various other errors (mainly node-sass related)